### PR TITLE
chore(ci): paso opcional para listar organizaciones iTop (DEBUG_ITOP_LIST)

### DIFF
--- a/.github/workflows/itop-cmdb-full-sync.yml
+++ b/.github/workflows/itop-cmdb-full-sync.yml
@@ -56,6 +56,31 @@ jobs:
       - name: Install Dependencies
         run: pip install requests
 
+      - name: List Organizations (debug)
+        if: ${{ vars.DEBUG_ITOP_LIST == 'true' }}
+        env:
+          ITOP_URL: ${{ secrets.ITOP_URL }}
+          ITOP_API_USER: ${{ secrets.ITOP_API_USER }}
+          ITOP_API_PASSWORD: ${{ secrets.ITOP_API_PASSWORD }}
+          ITOP_SSL_VERIFY: ${{ vars.ITOP_SSL_VERIFY || 'false' }}
+        run: |
+          python - <<'PY'
+          import os, json, requests
+          url = os.environ['ITOP_URL'].rstrip('/') + '/webservices/rest.php'
+          user = os.environ['ITOP_API_USER']
+          pwd = os.environ['ITOP_API_PASSWORD']
+          verify = os.environ.get('ITOP_SSL_VERIFY','true').strip().lower() != 'false'
+          payload = {
+              "operation": "core/get",
+              "class": "Organization",
+              "key": "SELECT Organization",
+              "output_fields": "id,name"
+          }
+          r = requests.post(url, auth=(user, pwd), data={"json_data": json.dumps(payload)}, verify=verify)
+          print("[DEBUG] Organizations payload response:")
+          print(r.text)
+          PY
+
       - name: Discover Services
         id: discover
         run: |


### PR DESCRIPTION
Añade un paso condicional para listar Organizations en iTop con ITOP_SSL_VERIFY configurable. Controlado por la variable de repositorio DEBUG_ITOP_LIST=true. Permite diagnosticar el nombre exacto de la organización para ITOP_ORIGIN.