### PR TITLE
chore(ci): debug iTop orgs añade version=1.3

### DIFF
--- a/.github/workflows/itop-cmdb-full-sync.yml
+++ b/.github/workflows/itop-cmdb-full-sync.yml
@@ -74,7 +74,8 @@ jobs:
               "operation": "core/get",
               "class": "Organization",
               "key": "SELECT Organization",
-              "output_fields": "id,name"
+              "output_fields": "id,name",
+              "version": "1.3"
           }
           r = requests.post(url, auth=(user, pwd), data={"json_data": json.dumps(payload)}, verify=verify)
           print("[DEBUG] Organizations payload response:")


### PR DESCRIPTION
Corrige el paso de depuración para listar Organizations en iTop incluyendo version=1.3 en el payload.