### PR TITLE
fix(cmdb-sync): org_id numérico en OQL y fields

### DIFF
--- a/.github/scripts/itop-cmdb-sync.py
+++ b/.github/scripts/itop-cmdb-sync.py
@@ -98,7 +98,10 @@ def get_organization_id(org_name):
     
     # Return the first key (ID)
     for key, val in objects.items():
-        return key
+        # Keys can be like "Organization::1" -> extract numeric id
+        if isinstance(key, str) and '::' in key:
+            return key.split('::')[-1]
+        return str(key)
     return None
 
 


### PR DESCRIPTION
Al resolver la Organización iTop, la clave devuelta puede ser 'Organization::N'. Se normaliza a 'N' para usar org_id numérico en OQL y en fields, evitando errores 'Unexpected input at line 1: :'.~