### PR TITLE
chore(ci): mitigar cancelaciones al cerrar múltiples incidentes

### DIFF
--- a/.github/workflows/github-sync-itop.yml
+++ b/.github/workflows/github-sync-itop.yml
@@ -20,6 +20,7 @@ env:
 
 jobs:
   core-execution:
+    if: ${{ ! (github.event_name == 'issues' && startsWith(github.event.issue.title, '[INCIDENT]:')) }}
     runs-on: swarm-runners-scaleset
     permissions:
       contents: write

--- a/.github/workflows/inspector.yml
+++ b/.github/workflows/inspector.yml
@@ -29,6 +29,9 @@ on:
         required: false
 permissions:
   contents: read
+concurrency:
+  group: inspector-${{ inputs.run_id || inputs.kaos-workflow-id || github.run_id }}
+  cancel-in-progress: true
 env:
   KAOS_MODULE: "[Ka0S] INSPECTOR"
   KAOS_CODE: ${{ github.run_id }}


### PR DESCRIPTION
- github-sync-itop: se omiten ejecuciones cuando el evento proviene de issues cuyo título comienza por [INCIDENT].\n- inspector.yml: se añade concurrency por run_id/kaos-workflow-id con cancel-in-progress=true para consolidar ejecuciones simultáneas.\n\nObjetivo: evitar carreras y cancelaciones visibles al cerrar incidentes en lote.