### PR TITLE
fix(agent): feedback workflow fallback PR url

### DIFF
--- a/.github/workflows/kaos-agent-feedback.yml
+++ b/.github/workflows/kaos-agent-feedback.yml
@@ -56,6 +56,7 @@ jobs:
           echo "path=$FILE_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Create PR
+        id: pr
         env:
           GH_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
@@ -77,21 +78,27 @@ jobs:
           git config user.email "github-actions@users.noreply.github.com"
           git commit -m "audit(feedback): issue ${ISSUE_NUMBER}"
           git push -u origin "$BRANCH"
-          gh pr create \
+          PR_URL=$(gh pr create \
             --title "audit(feedback): issue ${ISSUE_NUMBER}" \
             --body "Evidencia de feedback registrada en: \`${FILE_PATH}\`" \
             --base main \
-            --head "$BRANCH"
+            --head "$BRANCH" 2>/dev/null || true)
+          if [ -z "$PR_URL" ]; then
+            PR_URL="https://github.com/${{ github.repository }}/pull/new/$BRANCH"
+          fi
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
 
       - name: Acknowledge
         uses: actions/github-script@v7
         with:
           script: |
             const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const prUrl = '${{ steps.pr.outputs.pr_url }}';
+            const filePath = '${{ steps.capture.outputs.path }}';
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `✅ Feedback recibido. Queda auditado y trazado.\n\n🔗 Run: ${runUrl}`
+              body: `✅ Feedback recibido.\n- Evidencia: \`${filePath}\`\n- PR: ${prUrl}\n\n🔗 Run: ${runUrl}`
             });
 


### PR DESCRIPTION
El workflow de feedback fallaba porque GitHub Actions no tiene permisos para crear PRs en este repo.

Ahora:
- Si puede crear PR, comenta el link.
- Si no puede, comenta un link directo para abrir PR manualmente (pull/new/<branch>).

Así el run no falla y el feedback queda utilizable.
