### PR TITLE
fix(ci): Ka0s Agent Promote Eval Case heredoc

### DIFF
--- a/.github/workflows/kaos-agent-promote-eval.yml
+++ b/.github/workflows/kaos-agent-promote-eval.yml
@@ -66,32 +66,13 @@ jobs:
       - name: Promote Issue to Eval Case
         id: promote
         env:
+          GITHUB_TOKEN: ${{ github.token }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
           set -e
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            python - <<'PY' > /tmp/issue.txt
-            import json
-            import os
-            import urllib.request
-
-            repo = os.environ.get('GITHUB_REPOSITORY')
-            issue_number = os.environ.get('ISSUE_NUMBER')
-            token = os.environ.get('GITHUB_TOKEN')
-            url = f"https://api.github.com/repos/{repo}/issues/{issue_number}"
-            req = urllib.request.Request(url, headers={
-              'Accept': 'application/vnd.github+json',
-              'Authorization': f'Bearer {token}',
-            })
-            with urllib.request.urlopen(req, timeout=30) as r:
-              payload = json.loads(r.read().decode('utf-8'))
-            title = payload.get('title','')
-            body = payload.get('body','')
-            print(title)
-            print('---')
-            print(body)
-            PY
+            python -c "import json, os, urllib.request; repo=os.environ.get('GITHUB_REPOSITORY'); issue_number=os.environ.get('ISSUE_NUMBER'); token=os.environ.get('GITHUB_TOKEN'); url=f'https://api.github.com/repos/{repo}/issues/{issue_number}'; req=urllib.request.Request(url, headers={'Accept':'application/vnd.github+json','Authorization':f'Bearer {token}'}); payload=json.loads(urllib.request.urlopen(req, timeout=30).read().decode('utf-8')); print(payload.get('title','')); print('---'); print(payload.get('body',''))" > /tmp/issue.txt
             ISSUE_TITLE=$(sed -n '1p' /tmp/issue.txt)
             ISSUE_BODY=$(sed -n '3,$p' /tmp/issue.txt)
             export ISSUE_TITLE

--- a/audit/eresults/run_23319140412_promote_failure.md
+++ b/audit/eresults/run_23319140412_promote_failure.md
@@ -1,0 +1,24 @@
+# RCA: Ka0s Agent Promote Eval Case (run 23319140412)
+
+Run:
+- https://github.com/Ka0s-Klaus/ka0s/actions/runs/23319140412
+  - Job: `promote` (67826135317)
+
+Fallo:
+- Step: `Promote Issue to Eval Case`
+- Error:
+```text
+warning: here-document at line 3 delimited by end-of-file (wanted `PY')
+syntax error: unexpected end of file
+Process completed with exit code 2.
+```
+
+Causa raíz:
+- El step usa un heredoc `python - <<'PY'` dentro de `run: |`.
+- En GitHub Actions, el script está indentado (espacios) por YAML, por lo que el terminador `PY` no queda al inicio de línea.
+- Bash no reconoce el fin del heredoc y termina el script con error.
+
+Fix:
+- Evitar heredoc en ese step (usar `python -c` o un script `.py`).
+- Pasar `GITHUB_TOKEN` explícitamente al entorno del step.
+


### PR DESCRIPTION
RCA: el step `Promote Issue to Eval Case` fallaba con:
- `warning: here-document ... wanted 'PY'`
- `syntax error: unexpected end of file`

Causa: el heredoc `python - <<'PY'` estaba dentro de `run: |` y el terminador quedaba indentado (espacios), por lo que bash no lo reconocía.

Fix:
- Reemplaza el heredoc por `python -c` y pasa `GITHUB_TOKEN` explícitamente.
- Evidencia en `audit/eresults/run_23319140412_promote_failure.md`.

Run afectado: https://github.com/Ka0s-Klaus/ka0s/actions/runs/23319140412 (job 67826135317).