### PR TITLE
fix(ci): agent eval installs psycopg2

### DIFF
--- a/.github/workflows/kaos-agent-eval.yml
+++ b/.github/workflows/kaos-agent-eval.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install Dependencies
+        run: pip install psycopg2-binary requests
+
       - name: Run Offline Eval
         run: python core/ai/eval/run_eval.py
 

--- a/.github/workflows/kaos-agent-promote-eval.yml
+++ b/.github/workflows/kaos-agent-promote-eval.yml
@@ -38,6 +38,9 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install Dependencies
+        run: pip install psycopg2-binary requests
+
       - name: Compute Inputs
         id: vars
         shell: bash

--- a/audit/eresults/run_23319831479_promote_eval_failure.md
+++ b/audit/eresults/run_23319831479_promote_eval_failure.md
@@ -1,0 +1,22 @@
+# RCA: run 23319831479 (Ka0s Agent Promote Eval Case)
+
+Run:
+- https://github.com/Ka0s-Klaus/ka0s/actions/runs/23319831479
+
+Estado:
+- Workflow: `Ka0s Agent Promote Eval Case`
+- Job: `promote` (id `67828426560`)
+- Step fallido: `Run Offline Eval`
+
+Causa raíz:
+- `core/ai/eval/run_eval.py` ejecuta `core/ai/inference/query.py`.
+- En el runner no está instalada la dependencia `psycopg2`, por lo que `query.py` falla al importar:
+  - `ModuleNotFoundError: No module named 'psycopg2'`
+
+Impacto:
+- Se marcan como FAIL múltiples casos de eval (todos los que invocan `query.py`).
+- Los steps `Create PR` y `Comment Back` quedan `skipped`.
+
+Fix:
+- Añadir `pip install psycopg2-binary requests` antes de `python core/ai/eval/run_eval.py`.
+


### PR DESCRIPTION
RCA: el run https://github.com/Ka0s-Klaus/ka0s/actions/runs/23319831479 falla en `Run Offline Eval` por:
- `ModuleNotFoundError: No module named 'psycopg2'` (import en `core/ai/inference/query.py`).

Fix:
- Añade `pip install psycopg2-binary requests` antes de `python core/ai/eval/run_eval.py`.
- Aplica en:
  - `.github/workflows/kaos-agent-promote-eval.yml`
  - `.github/workflows/kaos-agent-eval.yml`

Evidencia: `audit/eresults/run_23319831479_promote_eval_failure.md`.