### PR TITLE
fix(ci): /feedback funciona con label ka0s-agent

### DIFF
--- a/.github/workflows/kaos-agent-feedback.yml
+++ b/.github/workflows/kaos-agent-feedback.yml
@@ -18,7 +18,10 @@ jobs:
   capture:
     if: >-
       github.event.issue.pull_request == null &&
-      contains(github.event.issue.labels.*.name, 'ka0s-agent-eval') &&
+      (
+        contains(github.event.issue.labels.*.name, 'ka0s-agent-eval') ||
+        contains(github.event.issue.labels.*.name, 'ka0s-agent')
+      ) &&
       startsWith(github.event.comment.body, '/feedback')
     runs-on: swarm-runners-scaleset
     steps:
@@ -100,5 +103,25 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
               body: `✅ Feedback recibido.\n- Evidencia: \`${filePath}\`\n- PR: ${prUrl}\n\n🔗 Run: ${runUrl}`
+            });
+
+  explain-skip:
+    if: >-
+      github.event.issue.pull_request == null &&
+      startsWith(github.event.comment.body, '/feedback') &&
+      !contains(github.event.issue.labels.*.name, 'ka0s-agent-eval') &&
+      !contains(github.event.issue.labels.*.name, 'ka0s-agent')
+    runs-on: swarm-runners-scaleset
+    steps:
+      - name: Explain Skip
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `⚠️ No pude capturar el feedback porque la issue no tiene labels de agente esperados.\n\nAñade el label \`ka0s-agent\` (o \`ka0s-agent-eval\`) y vuelve a comentar \`/feedback ...\`.\n\n🔗 Run: ${runUrl}`
             });
 


### PR DESCRIPTION
RCA: el run 23334027328 quedó `skipped` porque el job `capture` exigía el label `ka0s-agent-eval`, pero la issue #5072 solo tiene `ka0s-agent`.

Fix:
- Permite ejecutar feedback si la issue tiene `ka0s-agent-eval` **o** `ka0s-agent`.
- Añade un job `explain-skip` que comenta en la issue cuando alguien usa `/feedback` sin labels esperados.

Run afectado: https://github.com/Ka0s-Klaus/ka0s/actions/runs/23334027328
Issue: https://github.com/Ka0s-Klaus/ka0s/issues/5072