### PR TITLE
docs: AnythingLLM deploy (Ollama + NFS + límites)

### DIFF
--- a/core/docs/README.md
+++ b/core/docs/README.md
@@ -39,6 +39,7 @@ Si, parece increible pero hemos decidido en el equipo usar una terminología "es
 - [Ka0s Agent: Visión y Roadmap](./ka0s_agent_future/00_main.md)
 - [Ka0s Agent Ingest - Estrategia Modular](./ka0s_agent_ingest/00_main.md)
 - [Ka0s Agent Knowledge Pipeline (DB Embeddings)](./ka0s_agent_knowledge_pipeline/00_main.md)
+- [Ka0s AnythingLLM (Frontend de IA)](./ka0s_anythingllm/00_main.md)
 - [Arquitectura: Core (Núcleo del Sistema)](./ka0s_architecture/core.md)
 - [Módulo Ka0s Audit Failed Pods](./ka0s_audit_pods/00_main.md)
 - [Ka0s Kubernetes CI/CD Automation](./ka0s_ci_cd_k8s/00_main.md)

--- a/core/docs/ka0s_anythingllm/00_main.md
+++ b/core/docs/ka0s_anythingllm/00_main.md
@@ -1,0 +1,19 @@
+# Ka0s AnythingLLM (Frontend de IA)
+
+Este módulo documenta el despliegue de **AnythingLLM** como frontend colaborativo para consumir el **Ollama** ya desplegado en el clúster.
+
+El objetivo es que el equipo pueda compartir un único backend de modelos (Ollama) manteniendo persistencia de datos (workspaces, embeddings, documentos y configuración) en almacenamiento NFS.
+
+## Alcance
+
+- Frontend: AnythingLLM accesible por Ingress en `https://anythingllm.ka0s.io`.
+- Backend de inferencia/embeddings: Ollama (servicio existente).
+- Persistencia: PVC `ReadWriteMany` sobre `StorageClass` `nfs-client` (storage-system).
+- Restricción de nodo: AnythingLLM fijado a `k8-node-20`.
+- Control de consumo: runners ARC limitados a `maxRunners=10`.
+
+## Enlaces rápidos
+
+- [Concepto y arquitectura](01_concept.md)
+- [Uso y validación](02_usage_validation.md)
+- [Detalles técnicos](03_technical.md)

--- a/core/docs/ka0s_anythingllm/01_concept.md
+++ b/core/docs/ka0s_anythingllm/01_concept.md
@@ -1,0 +1,37 @@
+# Concepto y arquitectura (AnythingLLM)
+
+## Visión general
+
+AnythingLLM se despliega como una aplicación web self-hosted para:
+
+- Chat y gestión de workspaces.
+- Ingesta de documentos y RAG.
+- Integraciones/funcionalidades habilitadas desde su propia UI, manteniendo el despliegue siempre en la imagen `latest` del fabricante.
+
+En Ka0s, AnythingLLM se utiliza como **frontal** y delega generación/embeddings a **Ollama**.
+
+## Arquitectura (flujo)
+
+```mermaid
+flowchart LR
+  U[Usuarios] -->|HTTPS: anythingllm.ka0s.io| I[Ingress NGINX]
+  I --> S[Service ClusterIP anythingllm:3001]
+  S --> P[Pod anythingllm]
+  P -->|HTTP 11434| O[Service ollama.ollama.svc.cluster.local]
+  P -->|RWX| V[(PVC NFS: anythingllm-pvc)]
+```
+
+## Restricciones y decisiones
+
+- Nodo dedicado: AnythingLLM se fija a `k8-node-20` para concentrar el consumo en el nodo con más recursos.
+- Concurrencia esperada: equipo de hasta 10 personas y máximo 3 concurrentes.
+- Control de presión en entrada: el Ingress de AnythingLLM incluye límites básicos de conexión/rate.
+
+## Nota sobre “plugins”
+
+AnythingLLM evoluciona sus integraciones y capacidades por versión. En este despliegue se garantiza:
+
+- Imagen `mintplexlabs/anythingllm:latest` para traer las funcionalidades más recientes.
+- Persistencia en almacenamiento para que la configuración y workspaces sobrevivan a recreaciones del pod.
+
+La activación/uso de integraciones se gestiona desde la UI de AnythingLLM y puede requerir configuración adicional según el tipo de integración.

--- a/core/docs/ka0s_anythingllm/02_usage_validation.md
+++ b/core/docs/ka0s_anythingllm/02_usage_validation.md
@@ -1,0 +1,37 @@
+# Uso y validación (AnythingLLM)
+
+## Acceso
+
+- URL: `https://anythingllm.ka0s.io`
+
+## Primera configuración (usuario/contraseña)
+
+El despliegue no “inyecta” credenciales por manifiesto. En **el primer acceso**, AnythingLLM guía el alta inicial (modo de acceso y creación del primer usuario administrador) desde la propia interfaz web.
+
+Recomendación operativa:
+
+- Activar multi-user mode desde la UI.
+- Crear un admin inicial.
+- Crear usuarios para el equipo (hasta 10) y asignar workspaces/roles.
+
+## Validación de despliegue (GitOps/CD)
+
+El despliegue entra en el flujo CD del repo al vivir en `core/b2b/core-services/anythingllm/`.
+
+Comprobaciones esperadas tras el CD:
+
+- `Namespace` `anythingllm` existe.
+- `Deployment/Pod` `anythingllm` en `Running`.
+- `PVC` `anythingllm-pvc` en `Bound`.
+- `Ingress` resuelve host `anythingllm.ka0s.io` hacia el Service.
+
+## Validación de integración con Ollama
+
+Desde la UI de AnythingLLM:
+
+- Seleccionar proveedor LLM: `Ollama`.
+- Confirmar que el backend responde (el pod usa `OLLAMA_BASE_PATH` apuntando a `ollama.ollama.svc.cluster.local:11434`).
+
+## Nota sobre certificados
+
+El Ingress se publica por host. La terminación TLS se añadirá posteriormente cuando se instalen certificados.

--- a/core/docs/ka0s_anythingllm/03_technical.md
+++ b/core/docs/ka0s_anythingllm/03_technical.md
@@ -1,0 +1,78 @@
+# Detalles técnicos (Manifiestos y cambios)
+
+## Estado deseado (IaC)
+
+Cambios implementados inicialmente en la PR:
+
+- `https://github.com/Ka0s-Klaus/ka0s/pull/5107`
+
+El despliegue de AnythingLLM vive en:
+
+- `core/b2b/core-services/anythingllm/`
+
+Archivos principales:
+
+- `kustomization.yaml`: entrada Kustomize.
+- `namespace.yaml`: `Namespace` `anythingllm`.
+- `deployment.yaml`: `Deployment` y configuración de entorno.
+- `service.yaml`: `Service` ClusterIP `anythingllm:3001`.
+- `pvc.yaml`: PVC RWX sobre `StorageClass` `nfs-client`.
+- `ingress.yaml`: host `anythingllm.ka0s.io`.
+- `pull-embedding-model-job.yaml`: Job de pull del modelo de embedding en Ollama.
+
+## Nodo y scheduling
+
+- AnythingLLM: `nodeSelector: kubernetes.io/hostname: k8-node-20`.
+- Job de pull del embedding: ejecuta en `k8-node-20` (es CPU/IO, no requiere GPU).
+
+## Persistencia
+
+Se monta un PVC `ReadWriteMany` para persistir:
+
+- `/app/server/storage`
+- `/app/collector/hotdir`
+- `/app/collector/outputs`
+
+StorageClass:
+
+- `nfs-client` (provisioner NFS del `storage-system`).
+
+## Concurrencia y límites de entrada
+
+El Ingress aplica límites básicos:
+
+- `nginx.ingress.kubernetes.io/limit-connections: "3"`
+- `nginx.ingress.kubernetes.io/limit-rps: "5"`
+
+Estos valores están alineados con el objetivo: máximo ~3 concurrentes.
+
+## Integración con Ollama (variables)
+
+AnythingLLM se configura para usar Ollama por Service DNS interno:
+
+- `OLLAMA_BASE_PATH=http://ollama.ollama.svc.cluster.local:11434`
+- `EMBEDDING_BASE_PATH=http://ollama.ollama.svc.cluster.local:11434`
+
+Modelo de embeddings:
+
+- `EMBEDDING_MODEL_PREF=nomic-embed-text:latest`
+
+## Ajustes aplicados en Ollama
+
+En el Deployment de Ollama se ajustaron:
+
+- `OLLAMA_NUM_PARALLEL=4`
+- `OLLAMA_MAX_QUEUE=10`
+- `OLLAMA_KEEP_ALIVE=60m`
+- `OLLAMA_FLASH_ATTENTION=1`
+
+## Ajuste de ARC runners (FinOps)
+
+Se limitó la concurrencia máxima de runners:
+
+- `maxRunners: 10`
+
+## Referencias
+
+- Workflow CD Core Services: `.github/workflows/cd-core-services.yml`
+- Storage System (NFS provisioner): `core/b2b/core-services/storage-system/`

--- a/index.md
+++ b/index.md
@@ -66,6 +66,7 @@ Bienvenido al centro de documentación del proyecto Ka0s. A continuación encont
 *   [Ka0s Kubernetes Audits](core/docs/k8s-audits/00_main.md)
 *   [Ka0s Agent: Batería de pruebas y mejora iterativa](core/docs/ka0s_agent_eval/00_main.md)
 *   [Ka0s Agent: Visión y Roadmap](core/docs/ka0s_agent_future/00_main.md)
+*   [Ka0s AnythingLLM (Frontend de IA)](core/docs/ka0s_anythingllm/00_main.md)
 *   [Protocolo de Verificación de Incidencias (SOP)](core/docs/ka0s_incident_response/01_issue_verification.md)
 *   [Módulo Ka0s ITIL Sync](core/docs/ka0s_itil_sync/00_main.md)
 *   [Ka0s iTop Core Module](core/docs/ka0s_itop_core/00_main.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -133,6 +133,7 @@ nav:
       - 'Documentación del Módulo: Ka0s Self Service Portal': ka0s_self_service_portal/00_main.md
       - 'Ka0s Agent: Batería de pruebas y mejora iterativa': ka0s_agent_eval/00_main.md
       - 'Ka0s Agent: Visión y Roadmap': ka0s_agent_future/00_main.md
+      - 'Ka0s AnythingLLM (Frontend de IA)': ka0s_anythingllm/00_main.md
       - 'Ka0s Kubernetes Audits': k8s-audits/00_main.md
       - 'Ka0s Remediation Module': ka0s_remediation/00_main.md
       - 'Ka0s Remediation: High CPU/Load Workflow': ka0s_remediation_high_load/01_concept.md


### PR DESCRIPTION
Documentación añadida en core/docs/ka0s_anythingllm/ y actualización de índices usando .github/scripts/update-docs-index.py.

Referencia a la PR de despliegue: https://github.com/Ka0s-Klaus/ka0s/pull/5107